### PR TITLE
avoid instanceof Element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ const defaultValue: ElementDimensions = Object.assign(domRect, {
   target: (null as unknown) as Element,
 });
 
+const isElement = (element?: Element | null): element is $Element => {
+  return element?.nodeType === 1; // ELEMENT_NODE
+}
+
 const useDimensions = (): [
   ElementDimensions,
   (element?: Element | null) => void
@@ -85,8 +89,8 @@ const useDimensions = (): [
     if (ref.current) {
       resizeObserver.unobserve(ref.current);
     }
-    if (element instanceof Element) {
-      (element as $Element).$$useElementDimensionsSet = set;
+    if (isElement(element)) {
+      element.$$useElementDimensionsSet = set;
       resizeObserver.observe(element);
     }
   }, []);


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes a bug in apps with multiple windows, where there are multiple `Element` classes that an element could be an instance of.

- **What is the current behavior?** (You can also link to an open issue here)

If the element being observed is from another document, the resize observer will never be triggered.

- **What is the new behavior (if this is a feature change)?**

The hook should work correctly on elements from other documents.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

- **Other information**:
